### PR TITLE
uses -O3 instead -O3s/O3z

### DIFF
--- a/benchmarks/assemblyscript-multithreaded/Makefile
+++ b/benchmarks/assemblyscript-multithreaded/Makefile
@@ -1,5 +1,5 @@
-start: install 
-	npx asc assembly/mandel_final.ts -b build/mandel_final.wasm -t build/mandel_final.wat -O3z --runtime stub --converge --sourceMap --enable simd --enable threads --maximumMemory 80 --importMemory --noExportMemory --sharedMemory --initialMemory 80 --memoryBase 4000000
+start: install
+	npx asc assembly/mandel_final.ts -b build/mandel_final.wasm -t build/mandel_final.wat -O3 --runtime stub --converge --sourceMap --enable simd --enable threads --maximumMemory 80 --importMemory --noExportMemory --sharedMemory --initialMemory 80 --memoryBase 4000000
 
 install:
 	npm i

--- a/benchmarks/optimized-assemblyscript-singlethreaded/Makefile
+++ b/benchmarks/optimized-assemblyscript-singlethreaded/Makefile
@@ -1,5 +1,5 @@
-start: install 
-	npx asc assembly/mandel_final.ts -b build/mandel_final.wasm -t build/mandel_final.wat -O3z --runtime stub --converge --sourceMap --enable simd --enable threads --maximumMemory 80 --importMemory --noExportMemory --initialMemory 80 --memoryBase 4000000
+start: install
+	npx asc assembly/mandel_final.ts -b build/mandel_final.wasm -t build/mandel_final.wat -O3 --runtime stub --converge --sourceMap --enable simd --enable threads --maximumMemory 80 --importMemory --noExportMemory --initialMemory 80 --memoryBase 4000000
 
 install:
 	npm i

--- a/benchmarks/simd-assemblyscript-singlethreaded/Makefile
+++ b/benchmarks/simd-assemblyscript-singlethreaded/Makefile
@@ -1,9 +1,9 @@
 MEMORY_FLAGS = --maximumMemory 80 --importMemory --noExportMemory --initialMemory 80 --memoryBase 4000000
-OPTIMIZATION_FLAGS = -O3s --converge
+OPTIMIZATION_FLAGS = -O3 --converge
 DEBUG_FLAGS = --sourceMap
 FEATURE_FLAGS = --enable simd --enable threads
 RUNTIME_FLAGS = --runtime stub
-start: install 
+start: install
 	npx asc assembly/mandel_final.ts -b build/mandel_final.wasm -t build/mandel_final.wat $(OPTIMIZATION_FLAGS) $(MEMORY_FLAGS) $(FEATURE_FLAGS) $(RUNTIME_FLAGS) $(DEBUG_FLAGS)
 
 install:

--- a/benchmarks/simple-assemblyscript/Makefile
+++ b/benchmarks/simple-assemblyscript/Makefile
@@ -1,4 +1,4 @@
-out/main.wasm : install assembly/main.ts 
-	npx asc assembly/main.ts -b out/main.wasm -t out/main.wat -O3s --converge --maximumMemory 80 --importMemory --noExportMemory  --initialMemory 80 --memoryBase 2000000 --runtime stub
+out/main.wasm : install assembly/main.ts
+	npx asc assembly/main.ts -b out/main.wasm -t out/main.wat -O3 --converge --maximumMemory 80 --importMemory --noExportMemory  --initialMemory 80 --memoryBase 2000000 --runtime stub
 install:
 	npm i


### PR DESCRIPTION
In term of performance -O3 and -O3s/z sometimes pretty sensitive so better use -O3 